### PR TITLE
Remove -g option from calls to require.context

### DIFF
--- a/workspaces/doca/app/src/client/main.js
+++ b/workspaces/doca/app/src/client/main.js
@@ -8,19 +8,19 @@ try {
   const reqCSS = require.context(
     '@cloudflare/doca-default-theme/styles',
     true,
-    /\.css$/gi
+    /\.css$/i
   );
   reqCSS.keys().forEach(reqCSS);
   const reqLESS = require.context(
     '@cloudflare/doca-default-theme/styles',
     true,
-    /\.less$/gi
+    /\.less$/i
   );
   reqLESS.keys().forEach(reqLESS);
   const reqSASS = require.context(
     '@cloudflare/doca-default-theme/styles',
     true,
-    /\.scss$/gi
+    /\.scss$/i
   );
   reqSASS.keys().forEach(reqSASS);
 } catch (e) {


### PR DESCRIPTION
See https://webpack.js.org/guides/dependency-management/#require-context (v4.8.3 webpack).
Each file is tested against the RegExp argument so a -g option is not necessary.  This eliminates the webpack warnings in dev mode.