### PR TITLE
Update package.json to include the repository

### DIFF
--- a/workspaces/doca-default-theme/package.json
+++ b/workspaces/doca-default-theme/package.json
@@ -14,6 +14,11 @@
     "test": "jest --coverage",
     "clean": "rimraf build"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudflare/json-schema-tools.git",
+    "directory": "workspaces/doca-default-theme"
+  },
   "files": [
     "styles",
     "build"

--- a/workspaces/doca/package.json
+++ b/workspaces/doca/package.json
@@ -14,6 +14,11 @@
   "scripts": {
     "test": "jest --coverage"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudflare/json-schema-tools.git",
+    "directory": "workspaces/doca"
+  },
   "files": [
     "app",
     "example-schemas",

--- a/workspaces/json-hyper-schema/package.json
+++ b/workspaces/json-hyper-schema/package.json
@@ -11,6 +11,11 @@
   "scripts": {
     "test": "jest --coverage"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudflare/json-schema-tools.git",
+    "directory": "workspaces/json-hyper-schema"
+  },
   "dependencies": {
     "uri-templates": "^0.2.0"
   },

--- a/workspaces/json-schema-apidoc-loader/package.json
+++ b/workspaces/json-schema-apidoc-loader/package.json
@@ -11,6 +11,11 @@
   "scripts": {
     "test": "jest --coverage"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudflare/json-schema-tools.git",
+    "directory": "workspaces/json-schema-apidoc-loader"
+  },
   "files": [
     "lib"
   ],

--- a/workspaces/json-schema-ref-loader/package.json
+++ b/workspaces/json-schema-ref-loader/package.json
@@ -11,6 +11,11 @@
   "scripts": {
     "test": "jest --coverage"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudflare/json-schema-tools.git",
+    "directory": "workspaces/json-schema-ref-loader"
+  },
   "files": [
     "lib"
   ],

--- a/workspaces/json-schema-transform/package.json
+++ b/workspaces/json-schema-transform/package.json
@@ -17,6 +17,11 @@
       "/fixtures/"
     ]
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudflare/json-schema-tools.git",
+    "directory": "workspaces/json-schema-transform"
+  },
   "dependencies": {
     "@cloudflare/json-schema-walker": "^0.1.1",
     "json-schema-ref-parser": "^3.0.2",

--- a/workspaces/json-schema-walker/package.json
+++ b/workspaces/json-schema-walker/package.json
@@ -8,6 +8,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudflare/json-schema-tools.git",
+    "directory": "workspaces/json-schema-walker"
+  },
   "scripts": {
     "test": "jest --coverage"
   },


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @cloudflare/doca
* @cloudflare/doca-default-theme
* @cloudflare/json-hyper-schema
* @cloudflare/json-schema-apidoc-loader
* @cloudflare/json-schema-ref-loader
* @cloudflare/json-schema-transform
* @cloudflare/json-schema-walker